### PR TITLE
fix: handle unset tx type

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -299,6 +299,7 @@ impl RpcTx {
             Some(tx_type) if tx_type == &U64::from(1) => Ok(TxType::Eip2930),
             Some(tx_type) if tx_type == &U64::from(2) => Ok(TxType::Eip1559),
             Some(tx_type) if tx_type == &U64::from(3) => Ok(TxType::Eip4844),
+            None => Ok(TxType::Legacy),
             _ => Err(Error::InvalidTxVersion),
         }
     }

--- a/src/tx_receipt_trie.rs
+++ b/src/tx_receipt_trie.rs
@@ -161,7 +161,7 @@ mod tests {
     use alloy_primitives::hex;
     use alloy_primitives::B256;
 
-    const MAINNET_RPC_URL: &str = "https://mainnet.infura.io/v3/da91aac0e91048b3bf3be813262d43a6";
+    const MAINNET_RPC_URL: &str = "https://mainnet.infura.io/v3/720000a7936b45c79d0868f70478e2e9";
 
     // Test cases
     // Byzantium: 4370000

--- a/src/tx_trie.rs
+++ b/src/tx_trie.rs
@@ -155,7 +155,7 @@ mod tests {
     use alloy_primitives::hex;
     use alloy_primitives::B256;
 
-    const MAINNET_RPC_URL: &str = "https://mainnet.infura.io/v3/da91aac0e91048b3bf3be813262d43a6";
+    const MAINNET_RPC_URL: &str = "https://mainnet.infura.io/v3/720000a7936b45c79d0868f70478e2e9";
 
     // Test cases
     // Frontier: 46147


### PR DESCRIPTION
Some transactions dont have the TX type set, when querying from the rpc. These are then legacy transactions.