### PR TITLE
feat: expose trie struct and return payload in verification

### DIFF
--- a/src/tx_receipt_trie.rs
+++ b/src/tx_receipt_trie.rs
@@ -24,7 +24,7 @@ pub struct TxReceiptsMptHandler {
 /// The [`TxReceiptsMpt`] struct encapsulates the MPT (Merkle Patricia Trie) specifically for transaction receipts,
 /// including the trie structure itself, the [`ConsensusTxReceipt`] as elements, and the root hash.
 pub struct TxReceiptsMpt {
-    trie: EthTrie<MemoryDB>,
+    pub trie: EthTrie<MemoryDB>,
     elements: Vec<ConsensusTxReceipt>,
     root: B256,
 }
@@ -120,14 +120,14 @@ impl TxReceiptsMptHandler {
     }
 
     /// Verifies a proof for a transaction at a given index against the stored trie.
-    pub fn verify_proof(&self, tx_index: u64, proof: Vec<Vec<u8>>) -> Result<(), Error> {
+    pub fn verify_proof(&self, tx_index: u64, proof: Vec<Vec<u8>>) -> Result<Vec<u8>, Error> {
         let target_trie = self.trie.as_ref().ok_or(Error::TrieNotFound)?;
         match target_trie.trie.verify_proof(
             H256::from_slice(target_trie.root.as_slice()),
             alloy_rlp::encode(U256::from(tx_index)).as_slice(),
             proof,
         ) {
-            Ok(Some(_)) => Ok(()),
+            Ok(Some(result)) => Ok(result),
             _ => Err(Error::InvalidMPTProof),
         }
     }

--- a/src/tx_trie.rs
+++ b/src/tx_trie.rs
@@ -24,7 +24,7 @@ pub struct TxsMptHandler {
 /// The [`TxsMpt`] struct encapsulates the MPT (Merkle Patricia Trie) specifically for transactions,
 /// including the trie structure itself, the [`ConsensusTx`] as elements, and the root hash.
 pub struct TxsMpt {
-    trie: EthTrie<MemoryDB>,
+    pub trie: EthTrie<MemoryDB>,
     elements: Vec<ConsensusTx>,
     root: B256,
 }
@@ -114,14 +114,14 @@ impl TxsMptHandler {
     }
 
     /// Verifies a proof for a transaction at a given index against the stored trie.
-    pub fn verify_proof(&self, tx_index: u64, proof: Vec<Vec<u8>>) -> Result<(), Error> {
+    pub fn verify_proof(&self, tx_index: u64, proof: Vec<Vec<u8>>) -> Result<Vec<u8>, Error> {
         let target_trie = self.trie.as_ref().ok_or(Error::TrieNotFound)?;
         match target_trie.trie.verify_proof(
             H256::from_slice(target_trie.root.as_slice()),
             alloy_rlp::encode(U256::from(tx_index)).as_slice(),
             proof,
         ) {
-            Ok(Some(_)) => Ok(()),
+            Ok(Some(result)) => Ok(result),
             _ => Err(Error::InvalidMPTProof),
         }
     }


### PR DESCRIPTION
2 small changes that I realized are useful while working with the lib. 

1. Make underlying trie struct public, giving everything more flexibility
2. Return the verified data in the verification function