### PR TITLE
error unify with `thisiserror`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror",
  "tokio",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 serde = "1.0.197"
 serde_with = { version = "3.7.0", features = ["hex"] }
 serde_json = "1.0.114"
+thiserror = "1.0"
 
 [[bin]]
 name = "etp-cli"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde_with::serde_as;
 
 use eth_trie_proofs::tx_receipt_trie::TxReceiptsMptHandler;
-use eth_trie_proofs::Error;
+use eth_trie_proofs::EthTrieError;
 
 #[derive(Debug, Parser)]
 #[command(name = "eth-trie-proof")]
@@ -45,7 +45,7 @@ struct MptProof {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), EthTrieError> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Tx { tx_hash, rpc_url } => {
@@ -71,7 +71,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn generate_tx_proof(tx_hash: &str, rpc_url: &str) -> Result<(), Error> {
+async fn generate_tx_proof(tx_hash: &str, rpc_url: &str) -> Result<(), EthTrieError> {
     let rpc_url = url::Url::parse(rpc_url).expect("Invalid URL");
     let mut txs_mpt_handler = TxsMptHandler::new(rpc_url)?;
     let tx_hash = B256::from_hex(tx_hash).unwrap();
@@ -86,7 +86,7 @@ async fn generate_tx_proof(tx_hash: &str, rpc_url: &str) -> Result<(), Error> {
     Ok(())
 }
 
-async fn generate_receipt_proof(tx_hash: &str, rpc_url: &str) -> Result<(), Error> {
+async fn generate_receipt_proof(tx_hash: &str, rpc_url: &str) -> Result<(), EthTrieError> {
     let rpc_url = url::Url::parse(rpc_url).expect("Invalid URL");
     let mut tx_receipts_mpt_handler = TxReceiptsMptHandler::new(rpc_url)?;
     let tx_hash = B256::from_hex(tx_hash).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
+use core::fmt;
+
 use alloy::transports::{RpcError, TransportErrorKind};
 use eth_trie::TrieError;
+use thiserror::Error;
 
 mod rpc;
 pub mod tx;
@@ -7,19 +10,31 @@ pub mod tx_receipt;
 pub mod tx_receipt_trie;
 pub mod tx_trie;
 
-#[derive(Debug)]
-pub enum Error {
+#[derive(Error, Debug)]
+pub enum EthTrieError {
+    #[error("Trie error: {0}")]
     Trie(TrieError),
+    #[error("EIP error: {0}")]
     Eip(alloy::eips::eip2718::Eip2718Error),
+    #[error("RLP error: {0}")]
     Rlp(alloy_rlp::Error),
+    #[error("RPC error: {0}")]
     RPC(RpcError<TransportErrorKind>),
+    #[error("Transaction not found")]
     TxNotFound,
+    #[error("Block not found")]
     BlockNotFound,
+    #[error("Invalid transaction version")]
     InvalidTxVersion,
+    #[error("Error converting field: {0}")]
     ConversionError(Field),
+    #[error("Unexpected root")]
     UnexpectedRoot,
+    #[error("Invalid mpt proof")]
     InvalidMPTProof,
+    #[error("Invalid transaction trie")]
     TrieNotFound,
+    #[error("Field not found")]
     FieldNotFound,
 }
 
@@ -37,8 +52,25 @@ pub enum Field {
     Signature,
 }
 
-impl From<TrieError> for Error {
+impl fmt::Display for Field {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Field::ChainId => write!(f, "chain_id"),
+            Field::Nonce => write!(f, "nonce"),
+            Field::GasPrice => write!(f, "gas_price"),
+            Field::GasLimit => write!(f, "gas_limit"),
+            Field::Input => write!(f, "input"),
+            Field::AccessList => write!(f, "access_list"),
+            Field::MaxFeePerGas => write!(f, "max_fee_per_gas"),
+            Field::MaxPriorityFeePerGas => write!(f, "max_priority_fee_per_gas"),
+            Field::MaxFeePerBlobGas => write!(f, "max_fee_per_blob_gas"),
+            Field::Signature => write!(f, "signature"),
+        }
+    }
+}
+
+impl From<TrieError> for EthTrieError {
     fn from(err: TrieError) -> Self {
-        Error::Trie(err)
+        EthTrieError::Trie(err)
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::EthTrieError;
 use alloy::network::Ethereum;
 use alloy::primitives::B256;
 use alloy::providers::{Provider, RootProvider};
@@ -20,7 +20,7 @@ impl RpcProvider {
     pub(crate) async fn get_block_transactions(
         &self,
         block_number: u64,
-    ) -> Result<(Vec<Transaction>, B256), Error> {
+    ) -> Result<(Vec<Transaction>, B256), EthTrieError> {
         let block = self
             .provider
             .get_block(
@@ -28,11 +28,11 @@ impl RpcProvider {
                 alloy::rpc::types::BlockTransactionsKind::Full,
             )
             .await?
-            .ok_or_else(|| Error::BlockNotFound)?;
+            .ok_or_else(|| EthTrieError::BlockNotFound)?;
 
         let txs = match block.transactions {
             BlockTransactions::Full(txs) => txs,
-            _ => return Err(Error::TxNotFound),
+            _ => return Err(EthTrieError::TxNotFound),
         };
 
         Ok((txs, block.header.transactions_root))
@@ -41,7 +41,7 @@ impl RpcProvider {
     pub(crate) async fn get_block_transaction_receipts(
         &self,
         block_number: u64,
-    ) -> Result<(Vec<TransactionReceipt>, B256), Error> {
+    ) -> Result<(Vec<TransactionReceipt>, B256), EthTrieError> {
         let block = self
             .provider
             .get_block(
@@ -49,18 +49,18 @@ impl RpcProvider {
                 alloy::rpc::types::BlockTransactionsKind::Full,
             )
             .await?
-            .ok_or_else(|| Error::BlockNotFound)?;
+            .ok_or_else(|| EthTrieError::BlockNotFound)?;
 
         let tx_receipts = self
             .provider
             .get_block_receipts(block_number.into())
             .await?
-            .ok_or_else(|| Error::BlockNotFound)?;
+            .ok_or_else(|| EthTrieError::BlockNotFound)?;
 
         Ok((tx_receipts, block.header.receipts_root))
     }
 
-    pub(crate) async fn get_tx_index_by_hash(&self, tx_hash: B256) -> Result<u64, Error> {
+    pub(crate) async fn get_tx_index_by_hash(&self, tx_hash: B256) -> Result<u64, EthTrieError> {
         let tx = self
             .provider
             .get_transaction_by_hash(tx_hash)
@@ -69,13 +69,13 @@ impl RpcProvider {
 
         let index: u64 = match tx.transaction_index {
             Some(index) => index,
-            None => return Err(Error::TxNotFound),
+            None => return Err(EthTrieError::TxNotFound),
         };
 
         Ok(index)
     }
 
-    pub(crate) async fn get_tx_block_height(&self, tx_hash: B256) -> Result<u64, Error> {
+    pub(crate) async fn get_tx_block_height(&self, tx_hash: B256) -> Result<u64, EthTrieError> {
         let tx = self
             .provider
             .get_transaction_by_hash(tx_hash)
@@ -84,15 +84,15 @@ impl RpcProvider {
 
         let height: u64 = match tx.block_number {
             Some(height) => height,
-            None => return Err(Error::TxNotFound),
+            None => return Err(EthTrieError::TxNotFound),
         };
 
         Ok(height)
     }
 }
 
-impl From<RpcError<TransportErrorKind>> for Error {
+impl From<RpcError<TransportErrorKind>> for EthTrieError {
     fn from(err: RpcError<TransportErrorKind>) -> Self {
-        Error::RPC(err)
+        EthTrieError::RPC(err)
     }
 }

--- a/src/tx_receipt.rs
+++ b/src/tx_receipt.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::EthTrieError;
 use alloy::consensus::{Eip658Value, Receipt, ReceiptWithBloom, TxReceipt};
 use alloy::consensus::{ReceiptEnvelope, TxType};
 use alloy::eips::eip2718::Decodable2718;
@@ -15,8 +15,8 @@ impl ConsensusTxReceipt {
         self.0.encoded_2718()
     }
 
-    pub fn rlp_decode(mut data: &[u8]) -> Result<Self, Error> {
-        let envelope = ReceiptEnvelope::decode_2718(&mut data).map_err(Error::Eip)?;
+    pub fn rlp_decode(mut data: &[u8]) -> Result<Self, EthTrieError> {
+        let envelope = ReceiptEnvelope::decode_2718(&mut data).map_err(EthTrieError::Eip)?;
         Ok(ConsensusTxReceipt(envelope))
     }
 
@@ -65,8 +65,8 @@ impl ConsensusTxReceipt {
 pub(crate) struct RpcTxReceipt(pub TransactionReceipt);
 
 impl TryFrom<RpcTxReceipt> for ConsensusTxReceipt {
-    type Error = Error;
-    fn try_from(tx: RpcTxReceipt) -> Result<ConsensusTxReceipt, Error> {
+    type Error = EthTrieError;
+    fn try_from(tx: RpcTxReceipt) -> Result<ConsensusTxReceipt, EthTrieError> {
         match &tx.version()? {
             TxType::Legacy => {
                 let res = ReceiptEnvelope::Legacy(ReceiptWithBloom {
@@ -117,7 +117,7 @@ impl TryFrom<RpcTxReceipt> for ConsensusTxReceipt {
 }
 
 impl RpcTxReceipt {
-    fn version(&self) -> Result<TxType, Error> {
+    fn version(&self) -> Result<TxType, EthTrieError> {
         Ok(self.0.transaction_type())
     }
 

--- a/src/tx_receipt_trie.rs
+++ b/src/tx_receipt_trie.rs
@@ -9,7 +9,7 @@ use url::Url;
 use crate::{
     rpc::RpcProvider,
     tx_receipt::{ConsensusTxReceipt, RpcTxReceipt},
-    Error,
+    EthTrieError,
 };
 
 /// Represents a handler for transactions Merkle Patricia Trie (MPT) operations,
@@ -34,7 +34,7 @@ impl TxReceiptsMptHandler {
     /// Creates a new [`TxReceiptsMptHandler`] with a given RPC provider URL.
     ///
     /// This does not initialize the trie yet.
-    pub fn new(url: Url) -> Result<Self, Error> {
+    pub fn new(url: Url) -> Result<Self, EthTrieError> {
         let provider = RpcProvider::new(url);
         Ok(Self {
             provider,
@@ -45,7 +45,7 @@ impl TxReceiptsMptHandler {
     /// Retrieves the index of a transaction within the trie based on its hash.
     ///
     /// Returns an error if the trie is not found or the transaction does not exist.
-    pub async fn tx_hash_to_tx_index(&self, tx_hash: B256) -> Result<u64, Error> {
+    pub async fn tx_hash_to_tx_index(&self, tx_hash: B256) -> Result<u64, EthTrieError> {
         let tx_index = self.provider.get_tx_index_by_hash(tx_hash).await?;
         Ok(tx_index)
     }
@@ -53,7 +53,10 @@ impl TxReceiptsMptHandler {
     /// Builds the receipt trie from a specific transaction hash.
     ///
     /// This fetches the block height for the transaction and delegates to [`build_tx_receipts_tree_from_block`].
-    pub async fn build_tx_receipt_tree_from_tx_hash(&mut self, tx_hash: B256) -> Result<(), Error> {
+    pub async fn build_tx_receipt_tree_from_tx_hash(
+        &mut self,
+        tx_hash: B256,
+    ) -> Result<(), EthTrieError> {
         let height = self.provider.get_tx_block_height(tx_hash).await?;
         self.build_tx_receipts_tree_from_block(height).await?;
         Ok(())
@@ -65,7 +68,7 @@ impl TxReceiptsMptHandler {
     pub async fn build_tx_receipts_tree_from_block(
         &mut self,
         block_number: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<(), EthTrieError> {
         let (txs, tx_receipt_root) = self
             .provider
             .get_block_transaction_receipts(block_number)
@@ -87,7 +90,7 @@ impl TxReceiptsMptHandler {
         &mut self,
         tx_receipts: Vec<ConsensusTxReceipt>,
         expected_root: B256,
-    ) -> Result<(), Error> {
+    ) -> Result<(), EthTrieError> {
         let memdb = Arc::new(MemoryDB::new(true));
         let mut trie = EthTrie::new(memdb.clone());
 
@@ -97,7 +100,7 @@ impl TxReceiptsMptHandler {
             trie.insert(key.as_slice(), rlp.as_slice())?;
         }
         if trie.root_hash()?.as_bytes() != expected_root.as_slice() {
-            return Err(Error::UnexpectedRoot);
+            return Err(EthTrieError::UnexpectedRoot);
         }
 
         let result_mpt = TxReceiptsMpt {
@@ -111,8 +114,8 @@ impl TxReceiptsMptHandler {
     }
 
     /// Generates a proof for a transaction at a given index within the trie.
-    pub fn get_proof(&mut self, tx_index: u64) -> Result<Vec<Vec<u8>>, Error> {
-        let target_trie = self.trie.as_mut().ok_or(Error::TrieNotFound)?;
+    pub fn get_proof(&mut self, tx_index: u64) -> Result<Vec<Vec<u8>>, EthTrieError> {
+        let target_trie = self.trie.as_mut().ok_or(EthTrieError::TrieNotFound)?;
         let key = alloy_rlp::encode(U256::from(tx_index));
         let proof = target_trie.trie.get_proof(key.as_slice())?;
 
@@ -120,37 +123,41 @@ impl TxReceiptsMptHandler {
     }
 
     /// Verifies a proof for a transaction at a given index against the stored trie.
-    pub fn verify_proof(&self, tx_index: u64, proof: Vec<Vec<u8>>) -> Result<Vec<u8>, Error> {
-        let target_trie = self.trie.as_ref().ok_or(Error::TrieNotFound)?;
+    pub fn verify_proof(
+        &self,
+        tx_index: u64,
+        proof: Vec<Vec<u8>>,
+    ) -> Result<Vec<u8>, EthTrieError> {
+        let target_trie = self.trie.as_ref().ok_or(EthTrieError::TrieNotFound)?;
         match target_trie.trie.verify_proof(
             H256::from_slice(target_trie.root.as_slice()),
             alloy_rlp::encode(U256::from(tx_index)).as_slice(),
             proof,
         ) {
             Ok(Some(result)) => Ok(result),
-            _ => Err(Error::InvalidMPTProof),
+            _ => Err(EthTrieError::InvalidMPTProof),
         }
     }
 
     /// Retrieves a [`ConsensusTxReceipt`] by its index within the trie.
-    pub fn get_tx_receipt(&self, tx_index: u64) -> Result<ConsensusTxReceipt, Error> {
-        let target_trie = self.trie.as_ref().ok_or(Error::TrieNotFound)?;
+    pub fn get_tx_receipt(&self, tx_index: u64) -> Result<ConsensusTxReceipt, EthTrieError> {
+        let target_trie = self.trie.as_ref().ok_or(EthTrieError::TrieNotFound)?;
         target_trie
             .elements
             .get(tx_index as usize)
-            .ok_or(Error::TxNotFound)
+            .ok_or(EthTrieError::TxNotFound)
             .cloned()
     }
 
     /// Retrieves all elements within the trie.
-    pub fn get_elements(&self) -> Result<Vec<ConsensusTxReceipt>, Error> {
-        let target_trie = self.trie.as_ref().ok_or(Error::TrieNotFound)?;
+    pub fn get_elements(&self) -> Result<Vec<ConsensusTxReceipt>, EthTrieError> {
+        let target_trie = self.trie.as_ref().ok_or(EthTrieError::TrieNotFound)?;
         Ok(target_trie.elements.to_vec())
     }
 
     /// Retrieves the root hash of the trie.
-    pub fn get_root(&self) -> Result<B256, Error> {
-        let target_trie = self.trie.as_ref().ok_or(Error::TrieNotFound)?;
+    pub fn get_root(&self) -> Result<B256, EthTrieError> {
+        let target_trie = self.trie.as_ref().ok_or(EthTrieError::TrieNotFound)?;
         Ok(target_trie.root)
     }
 }


### PR DESCRIPTION
smol error format wrapping so that can be compatible with other error enum that use `thisiserror`